### PR TITLE
Sort the users by their spymaster frequency when creating teams

### DIFF
--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -54,6 +54,7 @@ export class UserService {
                 user = {name: userId, email: userId, rooms: []};
               }
               user.rooms = user.rooms || [];
+              user.id = userId;
               return user;
             }));
 


### PR DESCRIPTION
Sort the users by their spymaster frequency so that users who have been spymaster the least (compared to games played) will be chosen first