### PR TITLE
User to user stats

### DIFF
--- a/functions/src/games/onDelete.ts
+++ b/functions/src/games/onDelete.ts
@@ -9,7 +9,7 @@ try {
 const db = admin.firestore();
 
 import * as _ from 'lodash';
-import {recalcElo, nukeEloHistoryForGame} from '../util/elo';
+import {recalcElo, nukeHistoryForGame} from '../util/elo';
 import {Game} from '../../../types';
 
 export const onDeleteGame =
@@ -25,8 +25,9 @@ async function handleGameDeleted(game: Game) {
     // the future
     await db.collection('deletedGames').add(game);
 
-    // delete this elo history record and recalc elo, update league game stats
-    await nukeEloHistoryForGame(db, game.id!);
+    // delete all history records for this game and then recalc elo
+    await nukeHistoryForGame(db, 'eloHistory', game.id!);
+    await nukeHistoryForGame(db, 'userToUserHistory', game.id!);
     await recalcElo(db, game.createdAt, game);
   }
 }

--- a/functions/src/util/elo.ts
+++ b/functions/src/util/elo.ts
@@ -402,7 +402,7 @@ function maybeSetNemesis(
   const me = userMap[myUserId];
   const theirStats = userToUserMap[myUserId][theirUserId];
   const nemesisStats = userToUserMap[myUserId][me.nemesis || ''];
-  if (nemesisStats && nemesisStats.wonWith >= theirStats.wonWith) {
+  if (nemesisStats && nemesisStats.wonAgainst >= theirStats.wonAgainst) {
     return;
   }
 

--- a/src/app/pages/scorecard/scorecard.page.html
+++ b/src/app/pages/scorecard/scorecard.page.html
@@ -64,15 +64,21 @@
                 </ion-item>
                 <ion-item>
                   <h2>Last 7 Days</h2>
-                  <h2 slot="end">
-                    <app-elo-change [change]="elo7DaysAgo"></app-elo-change>
-                  </h2>
+                  <app-elo-change slot="end" [change]="elo7DaysAgo"></app-elo-change>
                 </ion-item>
                 <ion-item>
                   <h2>Last 30 Days</h2>
-                  <h2 slot="end">
-                    <app-elo-change [change]="elo30DaysAgo"></app-elo-change>
-                  </h2>
+                  <app-elo-change slot="end" [change]="elo30DaysAgo"></app-elo-change>
+                </ion-item>
+                <ion-item *ngIf="stats.ally">
+                  <h2>Ally</h2>
+                  <ion-icon name="help-circle-outline" tooltip="The player you have won with the most"></ion-icon>
+                  <app-user slot="end" [userId]="stats.ally"></app-user>
+                </ion-item>
+                <ion-item *ngIf="stats.nemesis">
+                  <h2>Nemesis</h2>
+                  <ion-icon name="help-circle-outline" tooltip="The player you have lost against the most"></ion-icon>
+                  <app-user slot="end" [userId]="stats.nemesis"></app-user>
                 </ion-item>
                 <ng-container *ngFor="let stat of overallStats">
                   <ion-item *ngIf="stats[stat.field] !== undefined">

--- a/src/app/pages/scorecard/scorecard.page.scss
+++ b/src/app/pages/scorecard/scorecard.page.scss
@@ -23,6 +23,10 @@
       .user-item {
         --ion-item-border-color: transparent;
       }
+
+      app-user {
+        margin-right: -5px;
+      }
     }
   }
 

--- a/types.ts
+++ b/types.ts
@@ -170,6 +170,8 @@ export interface UserStats {
   currentStreak: number;
   bestStreak: number;
   provisional: boolean;
+  ally?: string;
+  nemesis?: string;
   lastPlayed?: number|string;
 }
 

--- a/types.ts
+++ b/types.ts
@@ -200,3 +200,15 @@ export interface Message {
   userId?: string;
   team?: TeamTypes;
 }
+
+export interface UserToUserStats {
+  myUserId: string;
+  theirUserId: string;
+  gameId: string;
+  timestamp: number;
+  totalGames: number;
+  totalWith: number;
+  totalAgainst: number;
+  wonWith: number;
+  wonAgainst: number;
+}


### PR DESCRIPTION
For nemesis/ally stats feature:
[x] UserToUserStats type
[x] for each player update UserToUserStats for allies and nemesis
[x] update the userToUserHistory collection for each user where we update eloHistory
[x] nuke userToUserHistory on game deletion
[x] currentNemesis and currentAlly on UserStats (cloud function)
[x] display current nemesis/ally in general stats (in UI)
[ ] implement versus card
[ ] implement same team card

These last two are captured in other issues: #95 #96 