### PR TITLE
Fix the slowness of joining rooms from home

### DIFF
--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -19,7 +19,7 @@
         *ngFor="let roomId of roomIds"
         [roomId]="roomId"
       >
-        <ion-button size="small" slot="end" (click)="joinRoom(roomId)">Join</ion-button>
+        <ion-button size="small" slot="end" (click)="roomService.navToRoom(roomId)">Join</ion-button>
       </app-room-list-item>
     </div>
   </div>

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -1,5 +1,4 @@
 import {Component} from '@angular/core';
-import {Router} from '@angular/router';
 import {Observable} from 'rxjs';
 import {AuthService} from 'src/app/services/auth.service';
 import {RoomService} from 'src/app/services/room.service';
@@ -21,8 +20,7 @@ export class HomePage {
 
   constructor(
       public readonly authService: AuthService,
-      private readonly roomService: RoomService,
-      private readonly router: Router,
+      public readonly roomService: RoomService,
       private readonly userService: UserService,
   ) {}
 
@@ -52,14 +50,11 @@ export class HomePage {
   }
 
   async createRoom() {
-    if (this.roomName) {
-      const id = this.roomService.getRoomId(this.roomName);
-      localStorage.setItem(`roomName-${id}`, this.roomName);
-      this.joinRoom(id);
-    }
-  }
-
-  joinRoom(id: string) {
-    this.router.navigate([id]);
+    // ion-input updates the value after the keyup event, so we need to delay
+    setTimeout(() => {
+      if (this.roomName) {
+        this.roomService.navToRoom(this.roomName);
+      }
+    })
   }
 }

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -29,7 +29,7 @@ export class HomePage {
   ) {}
 
   get disabled(): boolean {
-    return this.roomService.createRoomId(this.roomName).length === 0;
+    return this.roomService.getRoomId(this.roomName).length === 0;
   }
 
   get roomIds(): string[] {
@@ -55,32 +55,13 @@ export class HomePage {
 
   async createRoom() {
     if (this.roomName) {
-      let loader;
-      if (!this.authService.authenticated) {
-        loader = await this.utilService.presentLoader('Logging in...');
-        await this.authService.loginWithGoogle();
-        await loader.dismiss();
-      }
-
-      loader = await this.utilService.presentLoader('Joining room...');
-      const id = await this.roomService.createRoom({
-        name: this.roomName,
-        status: RoomStatus.PREGAME,
-        timer: 120,
-        firstTurnTimer: 180,
-        guessIncrement: 30,
-        wordList: 'original',
-        enforceTimer: false,
-        userIds: []
-      });
-
+      const id = this.roomService.getRoomId(this.roomName);
+      localStorage.setItem(`roomName-${id}`, this.roomName);
       this.joinRoom(id);
-      await loader.dismiss();
     }
   }
 
   joinRoom(id: string) {
-    this.roomService.joinRoom(id);
     this.router.navigate([id]);
   }
 }

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -4,9 +4,8 @@ import {Observable} from 'rxjs';
 import {AuthService} from 'src/app/services/auth.service';
 import {RoomService} from 'src/app/services/room.service';
 import {UserService} from 'src/app/services/user.service';
-import {UtilService} from 'src/app/services/util.service';
 import {environment} from 'src/environments/environment';
-import {RoomStatus, WordList} from 'types';
+import {WordList} from 'types';
 
 @Component({
   selector: 'app-home',
@@ -24,7 +23,6 @@ export class HomePage {
       public readonly authService: AuthService,
       private readonly roomService: RoomService,
       private readonly router: Router,
-      private readonly utilService: UtilService,
       private readonly userService: UserService,
   ) {}
 

--- a/src/app/pages/room/room.page.ts
+++ b/src/app/pages/room/room.page.ts
@@ -155,10 +155,8 @@ export class RoomPage implements OnDestroy {
 
           // if this room doesn't exist, create a new room with the id
           if (!room.exists) {
-            const name = localStorage.getItem(`roomName-${room.id}`);
-            const id =
-                await this.roomService.createRoom({name: name || room.id});
-            this.router.navigate([id]);
+            const id = await this.roomService.createRoom({id: room.id});
+            this.roomService.navToRoom(id);
           }
         });
   }

--- a/src/app/pages/scorecard/scorecard.page.html
+++ b/src/app/pages/scorecard/scorecard.page.html
@@ -1,24 +1,26 @@
 <ion-header>
-  <ion-toolbar *ngIf="user$ | async as user">
+  <ion-toolbar>
     <ion-buttons slot="start">
       <ion-back-button></ion-back-button>
       <ion-button class="custom-back" [routerLink]="['/']">
         <ion-icon name="arrow-back" slot="icon-only"></ion-icon>
       </ion-button>
     </ion-buttons>
-    <ion-title>
-      <span *ngIf="user.nickname && user.nickname !== user.name" [tooltip]="user.name">
-        {{ user.nickname }}
-      </span>
-      <span *ngIf="!user.nickname">
-        {{ user.name }}
-      </span>
-    </ion-title>
-    <ion-buttons slot="end">
-      <ion-button (click)="promptForName(user)" *ngIf="isMe">
-        <ion-icon name="settings" slot="icon-only"></ion-icon>
-      </ion-button>
-    </ion-buttons>
+    <ng-container *ngIf="user$ | async as user">
+      <ion-title>
+        <span *ngIf="user.nickname && user.nickname !== user.name" [tooltip]="user.name">
+          {{ user.nickname }}
+        </span>
+        <span *ngIf="!user.nickname">
+          {{ user.name }}
+        </span>
+      </ion-title>
+      <ion-buttons slot="end">
+        <ion-button (click)="promptForName(user)" *ngIf="isMe">
+          <ion-icon name="settings" slot="icon-only"></ion-icon>
+        </ion-button>
+      </ion-buttons>
+    </ng-container>
   </ion-toolbar>
 </ion-header>
 

--- a/src/app/services/room.service.ts
+++ b/src/app/services/room.service.ts
@@ -13,7 +13,7 @@ const defaultRoom = {
   timer: 120,
   firstTurnTimer: 180,
   guessIncrement: 30,
-  wordList: 'original',
+  wordList: 'default',
   enforceTimer: false,
   userIds: []
 };

--- a/src/app/services/room.service.ts
+++ b/src/app/services/room.service.ts
@@ -15,7 +15,7 @@ const defaultRoom = {
   guessIncrement: 30,
   wordList: 'default',
   enforceTimer: false,
-  userIds: []
+  userIds: [],
 };
 
 @Injectable({providedIn: 'root'})

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {EventEmitter, Injectable} from '@angular/core';
 import {AngularFireAuth} from '@angular/fire/auth';
 import {AngularFirestore} from '@angular/fire/firestore';
 import {Observable, Subscription} from 'rxjs';
@@ -12,6 +12,7 @@ export class UserService {
 
   currentUser$?: Subscription;
   currentUser?: User;
+  userChanged$: EventEmitter<User>;
 
   constructor(
       private readonly afAuth: AngularFireAuth,
@@ -28,6 +29,8 @@ export class UserService {
         delete this.currentUser;
       }
     });
+
+    this.userChanged$ = new EventEmitter<User>();
   }
 
   subscribeToUser(uid: string) {
@@ -39,6 +42,7 @@ export class UserService {
     // subscribe to user changes
     this.currentUser$ = this.getUser(uid).subscribe(user => {
       this.currentUser = user;
+      this.userChanged$.emit(user);
     });
   }
 

--- a/types.ts
+++ b/types.ts
@@ -101,6 +101,7 @@ export interface Room {
 
   // client fields
   id?: string;
+  exists?: boolean;
 }
 
 // Stored at /games


### PR DESCRIPTION
Fix the slowness of joining rooms from the home page by routing directly to what the id would be of the sanitized string. `TangoCard` -> `tangocard` lobby. If the room does not exist when you reach the URL, that page will create the room for you