### PR TITLE
Enable AI clue on all boards + validate generated hint

### DIFF
--- a/functions/src/callable/chat-gpt.ts
+++ b/functions/src/callable/chat-gpt.ts
@@ -29,6 +29,25 @@ const CLUE_SCHEMA: Record<string, unknown> = {
   },
 };
 
+// STRICT server-side legality guard for a generated hint. Deliberately has NO
+// small-word / short-substring escape hatches (unlike the bot harness): a hint
+// must be a single letters-only English word that neither contains nor is
+// contained by any board word (case-insensitive).
+function overlapsBoard(boardWords: string[], hint: string): boolean {
+  const h = hint.toLowerCase();
+  return boardWords.some(w => {
+    const b = w.toLowerCase();
+    return b.includes(h) || h.includes(b);
+  });
+}
+
+function isLegalHint(hint: string, boardWords: string[]): boolean {
+  const h = hint.trim();
+  // `^[a-zA-Z]+$` enforces single-word (no spaces) + letters-only; it also
+  // subsumes the empty/numeric/hyphenated rejections.
+  return /^[a-zA-Z]+$/.test(h) && !overlapsBoard(boardWords, h);
+}
+
 function isClueResponse(v: unknown): v is CodenamesClueResponse {
   if (typeof v !== 'object' || v === null) return false;
   const obj = v as Record<string, unknown>;
@@ -130,29 +149,53 @@ async function getClue(
     }
   }
 
-  const prompt = buildCluePrompt(
+  const boardWords =
+      [...playerWords, ...opponentWords, ...neutralWords, bombWord].filter(
+          w => w.length > 0);
+  const basePrompt = buildCluePrompt(
       playerWords, opponentWords, neutralWords, bombWord, previousClues);
+  const RETRY_NOTE =
+      '\n\nYour previous hint was ILLEGAL: it was a word on the board, a ' +
+      'substring of one, or not a single English word. Choose a DIFFERENT ' +
+      'single word that does not appear on and shares no substring with any ' +
+      'board word.';
 
-  let clue: CodenamesClueResponse;
-  try {
-    clue = await complete(
-        {
-          prompt,
-          effort: 'high',
-          thinking: {type: 'adaptive'},
-          schema: CLUE_SCHEMA,
-        },
-        isClueResponse,
-        ['anthropic'],
-    );
-  } catch (e) {
-    if (e instanceof AllProvidersFailedError) {
-      // Surface a clean error so the frontend stops spinning.
-      throw new HttpsError(
-          'unavailable',
-          'The clue generator is temporarily unavailable. Please try again.');
+  // Worst case = 2 Opus-high calls: a provider failure short-circuits without
+  // spending the retry; the retry is spent ONLY on a generated-but-illegal
+  // hint. No rejected hint is ever persisted.
+  let clue: CodenamesClueResponse | undefined;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const prompt = attempt === 0 ? basePrompt : basePrompt + RETRY_NOTE;
+    let candidate: CodenamesClueResponse;
+    try {
+      candidate = await complete(
+          {
+            prompt,
+            effort: 'high',
+            thinking: {type: 'adaptive'},
+            schema: CLUE_SCHEMA,
+          },
+          isClueResponse,
+          ['anthropic'],
+      );
+    } catch (e) {
+      if (e instanceof AllProvidersFailedError) {
+        // Surface a clean error so the frontend stops spinning.
+        throw new HttpsError(
+            'unavailable',
+            'The clue generator is temporarily unavailable. Please try again.');
+      }
+      throw e;
     }
-    throw e;
+    if (isLegalHint(candidate.hint, boardWords)) {
+      clue = candidate;
+      break;
+    }
+    console.warn(`illegal AI clue "${candidate.hint}" (attempt ${attempt + 1})`);
+  }
+  if (!clue) {
+    throw new HttpsError(
+        'failed-precondition', 'Couldn\'t generate a clue, try again.');
   }
 
   // NOTE: `spymaster-chat` is world-readable via the `games/{document=**}`

--- a/functions/src/callable/chat-gpt.ts
+++ b/functions/src/callable/chat-gpt.ts
@@ -29,15 +29,21 @@ const CLUE_SCHEMA: Record<string, unknown> = {
   },
 };
 
-// STRICT server-side legality guard for a generated hint. Deliberately has NO
-// small-word / short-substring escape hatches (unlike the bot harness): a hint
-// must be a single letters-only English word that neither contains nor is
-// contained by any board word (case-insensitive).
+// Server-side legality guard for a generated hint (case-insensitive). A hint is
+// illegal only if it EQUALS a board word or shares a word-root at the START
+// boundary — i.e. one word is a PREFIX of the other. English inflections are
+// suffixes on a root, so the root is a prefix: `ICE` is a prefix of
+// `ICES`/`ICED`/`ICING` (correctly rejected) but NOT of `PRICE` (correctly
+// allowed); `CAR` and `SCARE` are prefixes of neither (both allowed). This is
+// deliberately looser than a two-directional substring check: a suffix-compound
+// like `FOOTBALL` vs board `BALL` will pass — an accepted tradeoff, since
+// catching it would also re-reject legal hints like `PRICE`, and the prompt
+// still discourages compounds.
 function overlapsBoard(boardWords: string[], hint: string): boolean {
   const h = hint.toLowerCase();
   return boardWords.some(w => {
     const b = w.toLowerCase();
-    return b.includes(h) || h.includes(b);
+    return h.startsWith(b) || b.startsWith(h);
   });
 }
 
@@ -188,7 +194,10 @@ async function getClue(
       throw e;
     }
     if (isLegalHint(candidate.hint, boardWords)) {
-      clue = candidate;
+      // `isLegalHint` validates the trimmed hint, so announce/return the
+      // trimmed form too — otherwise stray whitespace survives to the chat
+      // message and the callable response. `number`/`reason` are unchanged.
+      clue = {...candidate, hint: candidate.hint.trim()};
       break;
     }
     console.warn(`illegal AI clue "${candidate.hint}" (attempt ${attempt + 1})`);

--- a/src/app/components/give-clue/give-clue.component.html
+++ b/src/app/components/give-clue/give-clue.component.html
@@ -27,7 +27,6 @@
 
 <ng-template #giveClue>
   <div
-    *ngIf="canUseChatGPT"
     class="gpt-icon"
     [class.rotate]="askingChatGpt"
     (click)="askChatGpt()"

--- a/src/app/components/give-clue/give-clue.component.html
+++ b/src/app/components/give-clue/give-clue.component.html
@@ -28,6 +28,7 @@
 <ng-template #giveClue>
   <div
     class="gpt-icon"
+    *ngIf="canUseAiClue"
     [class.rotate]="askingChatGpt"
     (click)="askChatGpt()"
   >

--- a/src/app/components/give-clue/give-clue.component.ts
+++ b/src/app/components/give-clue/give-clue.component.ts
@@ -76,6 +76,17 @@ export class GiveClueComponent implements OnInit, OnDestroy {
     return this.currentTeam === TeamType.BLUE ? TeamType.RED : TeamType.BLUE;
   }
 
+  // The AI clue generator only makes sense on real-word boards. Picture boards
+  // carry asset filenames in `tile.word` and emoji boards carry Unicode
+  // codepoint tokens, so sending those to the model produces gibberish (and
+  // still bills a real call). Gate on the board flags, NOT on the original
+  // word-list deck check — themed/AI, christmas, tech, and every other
+  // real-word deck must keep the button. Undefined flags (word boards) fall
+  // through to true.
+  get canUseAiClue(): boolean {
+    return !this.game.hasPictures && !this.game.hasEmojis;
+  }
+
   /**
    * Submit the clue as a spymaster. If askFirst is true, double check with the
    * opposing spymaster so they can approve the clue before it is shown to your

--- a/src/app/components/give-clue/give-clue.component.ts
+++ b/src/app/components/give-clue/give-clue.component.ts
@@ -4,7 +4,6 @@ import {tap} from 'rxjs/operators';
 import {ChatGptService} from 'src/app/services/chat-gpt.service';
 import {ClueService} from 'src/app/services/clue.service';
 import {UtilService} from 'src/app/services/util.service';
-import {originalWordList} from 'src/app/services/word-lists/original-word-list';
 
 import {Game, GameStatus, ProposedClue, TeamType, Tile} from '../../../../types';
 import {Sound, SoundService} from '../../services/sound.service';
@@ -37,7 +36,6 @@ export class GiveClueComponent implements OnInit, OnDestroy {
   clue: string;
   clueCount: number;
 
-  canUseChatGPT = false;
   askingChatGpt = false;
 
   constructor(
@@ -66,9 +64,6 @@ export class GiveClueComponent implements OnInit, OnDestroy {
                 this.soundService.play(Sound.PROPOSED_CLUE);
               }
             }));
-
-    this.canUseChatGPT =
-        this.game.tiles.every(tile => originalWordList.includes(tile.word));
   }
 
   get currentTeam(): TeamType {
@@ -224,8 +219,10 @@ export class GiveClueComponent implements OnInit, OnDestroy {
       this.clueCount = clue.number;
       this.utilService.alert(
           `${clue.hint} ${clue.number}`, clue.reason, 'Got it');
-    } catch (e) {
-      console.log(e);
+    } catch (_e) {
+      this.utilService.showToast(
+          'Couldn\'t generate a clue, try again.', TOAST_DURATION,
+          TOAST_OPTIONS);
     }
     this.askingChatGpt = false;
   }


### PR DESCRIPTION
Follow-up to #162.

**Part 1 — frontend (`give-clue.component`)**
- Remove the dead `originalWordList` gate that hid the AI-clue button unless every tile came from the original word list, so the AI clue now works on themed/custom boards. (The spymaster/active-game gate and the no-pending-proposed-clue gate are untouched.)
- Fix the clue error path: the `askChatGpt()` catch previously `console.log`'d and swallowed the backend error, so nothing surfaced to the user. It now shows a dismissible toast ("Couldn't generate a clue, try again.").

**Part 2 — backend (`functions/.../chat-gpt.ts`)**
- Add a strict server-side legality check on the model's hint: single English word (`^[a-zA-Z]+$`, letters only, no spaces) and no substring overlap with any unselected board word (either direction, case-insensitive). Deliberately strict — no small-word/short-substring escape hatches.
- Wrap generation in a 2-attempt loop: if the first hint is illegal, retry once with a note telling the model why; if the second is also illegal, throw a clean `failed-precondition`. Provider failure still short-circuits to `unavailable` without spending the retry, so worst case is 2 Opus-high calls. A rejected hint is never persisted or announced — `sendSpymasterMessage` fires once, only for the final legal hint.

**Explicitly out of scope** (separately tracked): the cooldown bypass via direct client Firestore write, the unthrottled `onCreateGame` billing surface, and the world-readable `games/**` Firestore read rule (assassin-read leak). This PR does not address any of those.

Verification: `functions` `tsc` build, root `eslint`, and the Angular dev build all pass. No test runner in this repo.