### PR TITLE
Add saved, reusable AI wordlists (pin, 50-cap, sort/filter)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -80,5 +80,18 @@ service cloud.firestore {
       allow read: if true;
       allow write: if isAdmin();
     }
+
+    // AI-generated themed word pools, saved for reuse. Created and deleted
+    // (auto-cleanup) only server-side by the onCreateGame Cloud Function via
+    // the admin SDK, which bypasses this rule. The pregame picker reads them,
+    // and any authenticated user may toggle ONLY the `pinned` flag to protect
+    // a list from auto-cleanup — no other field may be changed from the client.
+    match /themedWordlists/{document=**} {
+      allow read: if true;
+      allow update: if request.auth != null
+                    && request.resource.data.diff(resource.data)
+                        .affectedKeys().hasOnly(['pinned']);
+      allow create, delete: if false;
+    }
   }
 }

--- a/functions/src/games/onCreate.ts
+++ b/functions/src/games/onCreate.ts
@@ -1,9 +1,12 @@
+import {createHash} from 'crypto';
 import * as admin from 'firebase-admin';
 import {onDocumentCreated} from 'firebase-functions/v2/firestore';
 
-import {Game, GameStatus, GameType, Room, Tile, TileRole, WordList} from '../types';
-import {getThemedWords} from '../util/chatgpt';
+import {Game, GameStatus, GameType, Room, ThemedWordlist, Tile, TileRole, WordList} from '../types';
+import {generateThemedWordPool} from '../util/chatgpt';
 import {anthropicApiKey, chatgptApiKey} from '../util/llm';
+
+const md5 = (s: string) => createHash('md5').update(s).digest('hex');
 
 function shuffle<T>(arr: T[]): T[] {
   const out = [...arr];
@@ -123,7 +126,7 @@ async function generateNewGameTiles(
   let words: string[];
   if (aiWordlistTheme) {
     try {
-      words = await getThemedWords(aiWordlistTheme);
+      words = await getThemedWordsForGame(aiWordlistTheme);
     } catch (_e) {
       console.error(
           'themed word generation failed; falling back to original list');
@@ -155,6 +158,75 @@ async function generateNewGameTiles(
   }
 
   return shuffle(tiles);
+}
+
+// Resolve the 25 words for a themed board. Reuses a previously-generated pool
+// for this theme when one exists (no AI call); otherwise generates a fresh full
+// pool, persists it keyed by the normalized theme, and samples from it. Every
+// reuse re-samples, so the same theme yields a different board each game.
+// Propagates AllProvidersFailedError only when there's no saved pool AND
+// generation fails — generateNewGameTiles catches it and falls back.
+async function getThemedWordsForGame(theme: string): Promise<string[]> {
+  const themeKey = theme.trim().toLowerCase();
+  // Deterministic doc ID => idempotent writes: two concurrent first-time
+  // generations for the same theme converge on one doc instead of duplicating.
+  // (Raw theme text can't be a doc ID — it may contain '/', be empty, or exceed
+  // Firestore's 1500-byte key limit.)
+  const ref = db.collection('themedWordlists').doc(md5(themeKey));
+
+  const snap = await ref.get();
+  let pool = snap.exists ? (snap.data() as ThemedWordlist).words ?? [] : [];
+
+  // No usable saved pool — generate a fresh one and persist it for next time.
+  if (pool.length < 25) {
+    pool = await generateThemedWordPool(theme);  // >= 25 words, or throws
+    if (pool.length >= 25) {
+      await ref.set(
+          {theme, themeKey, words: pool, createdAt: new Date().getTime()});
+      // The collection just grew — trim it back to the cap.
+      await enforceThemeCap();
+    }
+  }
+
+  return sampleWords(pool, 25);
+}
+
+// Keep the saved-theme collection from growing without bound: once it exceeds
+// SAVED_THEME_CAP, delete the oldest *unpinned* lists until it's back at the
+// cap. Pinned lists are never auto-deleted, so a heavily-pinned collection can
+// legitimately sit above the cap. Runs only after a new list is saved.
+const SAVED_THEME_CAP = 50;
+async function enforceThemeCap(): Promise<void> {
+  const col = db.collection('themedWordlists');
+  const all = (await col.orderBy('createdAt', 'asc').get()).docs;
+  const overflow = all.length - SAVED_THEME_CAP;
+  if (overflow <= 0) return;
+
+  const batch = db.batch();
+  let removed = 0;
+  for (const doc of all) {  // oldest first
+    if (removed >= overflow) break;
+    if (doc.get('pinned')) continue;  // protected
+    batch.delete(doc.ref);
+    removed++;
+  }
+  if (removed > 0) await batch.commit();
+}
+
+// Sample up to `count` unique, non-empty words from a pool without mutating it.
+// Mirrors getWords' copy-splice dedupe loop and is bounded by pool length so a
+// short pool terminates instead of spinning.
+function sampleWords(pool: string[], count: number): string[] {
+  const available = [...pool];
+  const picked = [] as string[];
+  while (picked.length < count && available.length > 0) {
+    const randomIndex = Math.floor(Math.random() * available.length);
+    const word = available.splice(randomIndex, 1)[0];
+    if (word !== undefined && word !== '' && !picked.includes(word)) {
+      picked.push(word);
+    }
+  }
+  return picked;
 }
 
 async function getWords(wordList: string): Promise<string[]> {

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -185,6 +185,23 @@ export interface WordList {
   words: string[];
 }
 
+// /themedWordlists — AI-generated themed word pools, saved for reuse so the
+// same theme can be replayed without another AI call. Written server-side by
+// the onCreateGame trigger; doc ID is md5(themeKey).
+export interface ThemedWordlist {
+  theme: string;      // theme as entered (for display)
+  themeKey: string;   // normalized theme (trim + lowercase); md5 of this = doc ID
+  words: string[];    // full AI-returned pool, deduped (not sliced to 25)
+  createdAt: number;
+
+  // when true, this list is protected from the auto-cleanup that caps the
+  // collection — a user "pinned" it. Toggled client-side by authed users.
+  pinned?: boolean;
+
+  // client field
+  id?: string;
+}
+
 export interface UserStats {
   elo: number;
   gamesPlayed: number;

--- a/functions/src/util/chatgpt.ts
+++ b/functions/src/util/chatgpt.ts
@@ -3,15 +3,6 @@ import {complete} from './llm';
 // Re-exported for callers that historically imported the secret from here.
 export {chatgptApiKey} from './llm';
 
-function shuffle<T>(arr: T[]): T[] {
-  const out = [...arr];
-  for (let i = out.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [out[i], out[j]] = [out[j], out[i]];
-  }
-  return out;
-}
-
 interface ThemedWords {
   theme: string;
   words: string[];
@@ -74,7 +65,12 @@ function isThemedWords(v: unknown): v is ThemedWords {
   return true;
 }
 
-export async function getThemedWords(theme: string): Promise<string[]> {
+// Generate a themed word pool via the LLM router. Returns the FULL deduped,
+// validated pool (>= 25 words) so callers can persist it and re-sample fresh
+// boards without another AI call. Propagates AllProvidersFailedError when the
+// whole provider chain fails — the caller (generateNewGameTiles) catches it and
+// falls back to a standard word list.
+export async function generateThemedWordPool(theme: string): Promise<string[]> {
   // Cap the untrusted, player-supplied theme before interpolating it into the
   // prompt so a huge theme string can't blow up the request.
   const safeTheme = theme.slice(0, MAX_THEME_LENGTH);
@@ -106,5 +102,7 @@ export async function getThemedWords(theme: string): Promise<string[]> {
       ['anthropic', 'openai'],
   );
 
-  return shuffle(cleanWords(result.words)).slice(0, 25);
+  // Return the entire deduped pool; sampling to a 25-tile board happens at the
+  // call site so a saved pool can produce a different board on each reuse.
+  return cleanWords(result.words);
 }

--- a/src/app/components/pregame/pregame.component.html
+++ b/src/app/components/pregame/pregame.component.html
@@ -82,6 +82,21 @@
           Clear
         </ion-button>
       </h5>
+      <ng-container *ngIf="(themedWordlists$ | async) as themes">
+        <div
+          class="theme-words"
+          *ngIf="getSavedWords(themes, room.aiWordlistTheme) as words"
+        >
+          <p class="theme-words-label">
+            Saved words for this theme ({{ words.length }}) — a random 25 are used each game:
+          </p>
+          <div class="theme-words-list">
+            <ion-chip *ngFor="let word of words" outline="true">
+              <ion-label>{{ word }}</ion-label>
+            </ion-chip>
+          </div>
+        </div>
+      </ng-container>
     </div>
     <div class="word-lists" *ngIf="!hasCustomTheme">
       <ion-card
@@ -94,6 +109,55 @@
         <ion-img [src]="list.url" *ngIf="!list.warning"></ion-img>
         <span *ngIf="list.comingSoon">COMING SOON</span>
       </ion-card>
+    </div>
+    <div
+      class="saved-themes"
+      *ngIf="!hasCustomTheme && (themedWordlists$ | async) as themes"
+    >
+      <div *ngIf="themes.length">
+        <h4>Saved Themes</h4>
+        <p class="saved-themes-hint">
+          Reuse a previously generated theme — no wait, no new AI call. Tap the
+          star to pin a favorite so it's never auto-removed.
+        </p>
+        <div class="saved-themes-controls">
+          <ion-searchbar
+            class="theme-search"
+            mode="ios"
+            placeholder="Filter themes"
+            [debounce]="150"
+            [(ngModel)]="themeFilter"
+          ></ion-searchbar>
+          <ion-select
+            interface="popover"
+            aria-label="Sort themes"
+            [(ngModel)]="themeSort"
+          >
+            <ion-select-option value="newest">Newest</ion-select-option>
+            <ion-select-option value="oldest">Oldest</ion-select-option>
+            <ion-select-option value="alpha">A–Z</ion-select-option>
+          </ion-select>
+        </div>
+        <ng-container *ngIf="displayedThemes(themes) as shown">
+          <div class="saved-themes-list">
+            <ion-chip
+              *ngFor="let theme of shown"
+              [class.pinned]="theme.pinned"
+              (click)="applyTheme(theme.theme)"
+            >
+              <ion-icon
+                [name]="theme.pinned ? 'star' : 'star-outline'"
+                [color]="theme.pinned ? 'warning' : 'medium'"
+                (click)="togglePin(theme, $event)"
+              ></ion-icon>
+              <ion-label>{{ theme.theme }}</ion-label>
+            </ion-chip>
+          </div>
+          <p class="no-matches" *ngIf="!shown.length">
+            No themes match “{{ themeFilter }}”.
+          </p>
+        </ng-container>
+      </div>
     </div>
     <h3>Timer Settings</h3>
     <div class="timer-settings">

--- a/src/app/components/pregame/pregame.component.scss
+++ b/src/app/components/pregame/pregame.component.scss
@@ -42,6 +42,27 @@
           margin-left: 16px;
         }
       }
+
+      .theme-words {
+        margin-top: 8px;
+
+        .theme-words-label {
+          margin: 0 0 6px;
+          font-size: 0.8rem;
+          color: #7f7f7f;
+        }
+
+        .theme-words-list {
+          display: flex;
+          flex-wrap: wrap;
+          max-height: 180px;
+          overflow-y: auto;
+
+          ion-chip {
+            margin: 3px;
+          }
+        }
+      }
     }
 
     .word-lists {
@@ -85,6 +106,65 @@
             padding: 10px;
             font-weight: bold;
           }
+        }
+      }
+    }
+
+    .saved-themes {
+      margin: 8px 0 24px;
+
+      h4 {
+        margin: 0 0 4px;
+      }
+
+      .saved-themes-hint {
+        margin: 0 0 8px;
+        font-size: 0.8rem;
+        color: #7f7f7f;
+      }
+
+      .saved-themes-controls {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 4px;
+
+        .theme-search {
+          flex: 1;
+          padding: 0;
+          --box-shadow: none;
+          --background: var(--ion-color-light);
+        }
+
+        ion-select {
+          flex-shrink: 0;
+          max-width: 120px;
+        }
+      }
+
+      .saved-themes-list {
+        display: flex;
+        flex-wrap: wrap;
+        max-height: 220px;
+        overflow-y: auto;
+      }
+
+      .no-matches {
+        font-size: 0.8rem;
+        color: #7f7f7f;
+        margin: 4px 0 0;
+      }
+
+      ion-chip {
+        cursor: pointer;
+
+        ion-icon {
+          margin-right: 4px;
+          font-size: 1rem;
+        }
+
+        &.pinned {
+          border: 1px solid var(--ion-color-warning);
         }
       }
     }

--- a/src/app/components/pregame/pregame.component.ts
+++ b/src/app/components/pregame/pregame.component.ts
@@ -4,7 +4,7 @@ import {AuthService} from 'src/app/services/auth.service';
 import {UserService} from 'src/app/services/user.service';
 import {UtilService} from 'src/app/services/util.service';
 
-import {Game, GameType, Room, RoomStatus, Team, TeamType, User} from '../../../../types';
+import {Game, GameType, Room, RoomStatus, Team, TeamType, ThemedWordlist, User} from '../../../../types';
 import {GameService} from '../../services/game.service';
 import {RoomService} from '../../services/room.service';
 import {WordListsService} from '../../services/word-lists.service';
@@ -23,6 +23,11 @@ export class PregameComponent implements OnChanges {
   teams: Team[];
   constructedGame: Partial<Game>;
   debounce = 500;
+
+  // previously-generated AI themes, offered for one-click reuse (no AI call)
+  themedWordlists$: Observable<ThemedWordlist[]>;
+  themeFilter = '';
+  themeSort: 'newest'|'oldest'|'alpha' = 'newest';
 
   lastSettings: Partial<Room>;
 
@@ -55,7 +60,9 @@ export class PregameComponent implements OnChanges {
       private readonly utilService: UtilService,
       private readonly userService: UserService,
       private readonly wordListsService: WordListsService,
-  ) {}
+  ) {
+    this.themedWordlists$ = this.wordListsService.getThemedWordlists();
+  }
 
   ngOnChanges() {
     const {redReady = false, blueReady = false} = this.room || {};
@@ -95,6 +102,54 @@ export class PregameComponent implements OnChanges {
 
   get hasCustomTheme(): boolean {
     return !!this.room?.aiWordlistTheme;
+  }
+
+  // The saved word pool for the room's current theme, if that theme has one
+  // (i.e. it was previously generated). Returns undefined for a freshly-typed
+  // theme that hasn't been generated/saved yet. Matching is on the normalized
+  // themeKey, mirroring how the backend keys the saved pool.
+  getSavedWords(themes: ThemedWordlist[], theme?: string): string[]|undefined {
+    if (!theme) return undefined;
+    const themeKey = theme.trim().toLowerCase();
+    return themes.find(t => t.themeKey === themeKey)?.words;
+  }
+
+  // Apply the current filter text and sort order to the saved themes, always
+  // floating pinned lists to the top. Array.sort is stable, so the chosen sort
+  // is preserved within the pinned and unpinned groups.
+  displayedThemes(themes: ThemedWordlist[]): ThemedWordlist[] {
+    const query = this.themeFilter.trim().toLowerCase();
+    const list = query ?
+        themes.filter(t => t.theme.toLowerCase().includes(query)) :
+        [...themes];
+
+    switch (this.themeSort) {
+      case 'oldest':
+        list.sort((a, b) => a.createdAt - b.createdAt);
+        break;
+      case 'alpha':
+        list.sort((a, b) => a.theme.localeCompare(b.theme));
+        break;
+      default:  // newest
+        list.sort((a, b) => b.createdAt - a.createdAt);
+    }
+    list.sort((a, b) => (b.pinned ? 1 : 0) - (a.pinned ? 1 : 0));
+    return list;
+  }
+
+  // Toggle a saved theme's pinned flag. Requires auth (Firestore rules gate the
+  // write); pinned lists are exempt from the backend's 50-list auto-cleanup.
+  async togglePin(theme: ThemedWordlist, event: Event) {
+    event.stopPropagation();  // don't also select the theme
+    if (!this.authService.authenticated) {
+      this.utilService.showToast('Sign in to pin themes');
+      return;
+    }
+    try {
+      await this.wordListsService.setThemePinned(theme.id!, !theme.pinned);
+    } catch (_e) {
+      this.utilService.showToast('Could not update pin');
+    }
   }
 
   selectWordList(wordList: string) {
@@ -296,20 +351,27 @@ export class PregameComponent implements OnChanges {
     );
 
     if (theme) {
-      // If we're in ASSIGNING_ROLES phase and there's an existing game,
-      // we need to delete the current game and create a new one to regenerate the board
-      if (this.room.status === RoomStatus.ASSIGNING_ROLES && this.game) {
-        await this.regenerateGame({
-          aiWordlistTheme: theme,
-          wordList: '',
-        });
-      } else {
-        // In PREGAME phase, just update the theme
-        await this.roomService.updateRoom(this.room.id, {
-          aiWordlistTheme: theme,
-          wordList: '',
-        });
-      }
+      await this.applyTheme(theme);
+    }
+  }
+
+  // Set the room's AI theme (used by both the free-text prompt and the
+  // saved-theme picker). When a saved theme is selected, the onCreateGame
+  // trigger finds its persisted word pool and skips the AI call.
+  async applyTheme(theme: string) {
+    // If we're in ASSIGNING_ROLES phase and there's an existing game,
+    // we need to delete the current game and create a new one to regenerate the board
+    if (this.room.status === RoomStatus.ASSIGNING_ROLES && this.game) {
+      await this.regenerateGame({
+        aiWordlistTheme: theme,
+        wordList: '',
+      });
+    } else {
+      // In PREGAME phase, just update the theme
+      await this.roomService.updateRoom(this.room.id, {
+        aiWordlistTheme: theme,
+        wordList: '',
+      });
     }
   }
 

--- a/src/app/services/word-lists.service.ts
+++ b/src/app/services/word-lists.service.ts
@@ -6,11 +6,13 @@ import {
   doc,
   DocumentReference,
   Firestore,
+  orderBy,
+  query,
   setDoc,
   updateDoc,
 } from '@angular/fire/firestore';
 import {Observable} from 'rxjs';
-import {GameType, WordList} from 'types';
+import {GameType, ThemedWordlist, WordList} from 'types';
 
 import {christmasWordList} from './word-lists/christmas-word-list';
 import {deepUndercoverWordList} from './word-lists/deep-undercover-word-list';
@@ -49,6 +51,23 @@ export class WordListsService {
   getWordLists(): Observable<WordList[]> {
     return collectionData(collection(this.firestore, 'wordlists')) as
         Observable<WordList[]>;
+  }
+
+  // Previously-generated AI themes, newest first. Selecting one reuses its
+  // saved word pool (no AI call) — the onCreateGame trigger looks the theme up
+  // by name when a game is created.
+  getThemedWordlists(): Observable<ThemedWordlist[]> {
+    return collectionData(
+               query(
+                   collection(this.firestore, 'themedWordlists'),
+                   orderBy('createdAt', 'desc')),
+               {idField: 'id'}) as Observable<ThemedWordlist[]>;
+  }
+
+  // Pin/unpin a saved theme to protect it from (or expose it to) the backend's
+  // auto-cleanup. Firestore rules only permit the `pinned` field to change here.
+  setThemePinned(id: string, pinned: boolean): Promise<void> {
+    return updateDoc(doc(this.firestore, 'themedWordlists', id), {pinned});
   }
 
   createWordList(name: string, words: string[]): Promise<DocumentReference> {

--- a/types.ts
+++ b/types.ts
@@ -179,6 +179,23 @@ export interface WordList {
   words: string[];
 }
 
+// /themedWordlists — AI-generated themed word pools, saved for reuse so the
+// same theme can be replayed without another AI call. Written server-side by
+// the onCreateGame trigger; doc ID is md5(themeKey).
+export interface ThemedWordlist {
+  theme: string;      // theme as entered (for display)
+  themeKey: string;   // normalized theme (trim + lowercase); md5 of this = doc ID
+  words: string[];    // full AI-returned pool, deduped (not sliced to 25)
+  createdAt: number;
+
+  // when true, this list is protected from the auto-cleanup that caps the
+  // collection — a user "pinned" it. Toggled client-side by authed users.
+  pinned?: boolean;
+
+  // client field
+  id?: string;
+}
+
 export interface UserStats {
   elo: number;
   gamesPlayed: number;


### PR DESCRIPTION
## What & why

Custom AI themes were regenerated on **every** game and thrown away — each themed game cost another AI call, with no way to replay a theme. This persists the generated word pool keyed by theme, so any room can **replay a theme with no new AI call**, and adds a saved-theme picker to the pregame screen.

## Changes

- **Reuse:** `onCreateGame` looks up `themedWordlists/{md5(themeKey)}` — reuses the saved pool (sampling a fresh 25 each time) if present, else generates → persists → samples. Deterministic doc ID keeps concurrent first writes idempotent.
- **Cap:** after saving a new list, trim the collection to **50**, deleting the oldest **unpinned** first.
- **Pregame UI:** Saved Themes picker with filter, sort (Newest / Oldest / A–Z), pinned-to-top, per-chip pin star, and the selected theme's word pool shown in a list.
- **Rules:** `themedWordlists` — public read; create/delete server-only; authed users may change **only** `pinned`.
- **Types:** new `ThemedWordlist` (with `pinned`) in both type files.

## Verification

Lint + functions `tsc` + `ng build` pass. Emulator-verified: reuse (no dup doc / no AI call), re-sample variety, keyless fallback, 50-cap cleanup (pinned survive, idempotent), and pin-rule scoping (word/rename/delete/create from a client all denied).

## Notes

- Pinning is **global** (shared-library model) — easy to scope to owner/admin later.
- Deploy needs `firebase deploy --only firestore:rules` for the new collection + pin rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="630" height="331" alt="Screenshot 2026-07-17 at 08 47 11" src="https://github.com/user-attachments/assets/e57f640f-a5a5-446c-8683-67b00757d230" />
<img width="595" height="270" alt="Screenshot 2026-07-17 at 08 47 17" src="https://github.com/user-attachments/assets/a499e68e-a88b-4560-99cd-bf4418c3666e" />

