### PR TITLE
Add a post-game stats dialog

### DIFF
--- a/src/app/components/components.module.ts
+++ b/src/app/components/components.module.ts
@@ -12,6 +12,7 @@ import {EloChangeComponent} from './elo-change/elo-change.component';
 import {EloChartComponent} from './elo-chart/elo-chart';
 import {GameBoardComponent} from './game-board/game-board.component';
 import {GameCardComponent} from './game-card/game-card.component';
+import {GameStatsComponent} from './game-stats/game-stats.component';
 import {GameComponent} from './game/game.component';
 import {GiveClueComponent} from './give-clue/give-clue.component';
 import {PregameComponent} from './pregame/pregame.component';
@@ -37,6 +38,7 @@ import {WordHistoryComponent} from './word-history/word-history.component';
     EloChangeComponent,      SameTeamComponent,
     VersusComponent,         WinRecordComponent,
     ActionsPopoverComponent, ActionsPopoverPageComponent,
+    GameStatsComponent,
   ],
   imports: [
     IonicModule,
@@ -55,6 +57,7 @@ import {WordHistoryComponent} from './word-history/word-history.component';
     EloChangeComponent,      SameTeamComponent,
     VersusComponent,         WinRecordComponent,
     ActionsPopoverComponent, ActionsPopoverPageComponent,
+    GameStatsComponent,
   ]
 })
 export class ComponentsModule {

--- a/src/app/components/game-stats/game-stats.component.html
+++ b/src/app/components/game-stats/game-stats.component.html
@@ -1,0 +1,169 @@
+<ion-header>
+  <ion-toolbar [color]="blueWon ? 'primary' : 'danger'">
+    <ion-title>Game Stats</ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="dismiss()">
+        <ion-icon slot="icon-only" name="close"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ng-container *ngIf="!loading; else spinner">
+
+    <!-- winner hero -->
+    <div class="hero">
+      <h1 class="winner" [class.blue]="blueWon" [class.red]="!blueWon">
+        {{ blueWon ? "Blue" : "Red" }} Team Wins!
+      </h1>
+      <div class="hero-chips">
+        <ion-chip [outline]="true">
+          <ion-icon name="time-outline"></ion-icon>
+          <ion-label>{{ gameDurationText || "?" }}</ion-label>
+        </ion-chip>
+        <ion-chip [outline]="true">
+          <ion-icon name="chatbubble-ellipses-outline"></ion-icon>
+          <ion-label>{{ clues.length }} clues</ion-label>
+        </ion-chip>
+        <ion-chip [outline]="true">
+          <ion-icon name="hand-left-outline"></ion-icon>
+          <ion-label>{{ totalGuesses }} guesses</ion-label>
+        </ion-chip>
+        <ion-chip [outline]="true" color="dark" *ngIf="endedByAssassin">
+          <ion-icon name="skull"></ion-icon>
+          <ion-label>Ended by assassin</ion-label>
+        </ion-chip>
+      </div>
+    </div>
+
+    <!-- no clue history recorded (older games) -->
+    <div class="empty-container" *ngIf="clues.length === 0">
+      No clue history was recorded for this game, so detailed stats aren't
+      available.
+    </div>
+
+    <!-- awards -->
+    <ng-container *ngIf="awards.length">
+      <h2>Awards</h2>
+      <div class="awards-grid">
+        <div class="award-card" *ngFor="let award of awards">
+          <div class="award-emoji">{{ award.emoji }}</div>
+          <div class="award-title">{{ award.title }}</div>
+          <app-user [userId]="award.userId" [navToScorecard]="false"></app-user>
+          <div class="award-detail">{{ award.detail }}</div>
+        </div>
+      </div>
+    </ng-container>
+
+    <!-- team summaries + player tables -->
+    <h2>Teams</h2>
+    <div class="team-section" *ngFor="let team of teamSummaries">
+      <div class="team-header">
+        <span class="team-name {{ team.cssClass }}">{{ team.label }}</span>
+        <span class="team-score" *ngIf="team.total">
+          {{ team.found }}/{{ team.total }} agents found
+        </span>
+      </div>
+      <div class="accuracy-bar" *ngIf="team.guesses" tooltip="Guess accuracy">
+        <div
+          class="fill {{ team.cssClass }}"
+          [style.width.%]="team.accuracyPct">
+        </div>
+        <span class="accuracy-label">
+          {{ team.correct }}/{{ team.guesses }} correct ({{ team.accuracyPct }}%)
+        </span>
+      </div>
+      <table class="stats-table">
+        <thead>
+          <tr>
+            <th class="player-col">Player</th>
+            <th tooltip="Guesses made">🖱️</th>
+            <th tooltip="Correct guesses">✅</th>
+            <th tooltip="Civilians hit">🙈</th>
+            <th tooltip="Enemy agents revealed">🎁</th>
+            <th tooltip="Assassin!">💀</th>
+            <th tooltip="Darts thrown">🎯</th>
+            <th tooltip="Elo rating change">Elo</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let player of team.players">
+            <td class="player-col">
+              <span class="spy" *ngIf="player.isSpymaster" tooltip="Spymaster">🕵</span>
+              <app-user
+                [userId]="player.userId"
+                [color]="team.cssClass"
+                [navToScorecard]="false">
+              </app-user>
+            </td>
+            <td>{{ player.guesses }}</td>
+            <td>{{ player.correct }}</td>
+            <td>{{ player.civilians }}</td>
+            <td>{{ player.enemy }}</td>
+            <td>{{ player.assassin }}</td>
+            <td>{{ player.darts }}</td>
+            <td>
+              <app-elo-change [change]="player.eloDelta"></app-elo-change>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- spymaster duel -->
+    <ng-container *ngIf="spymasters.length">
+      <h2>Spymaster Duel</h2>
+      <div class="spymaster-grid">
+        <div class="spymaster-card {{ spymaster.cssClass }}" *ngFor="let spymaster of spymasters">
+          <app-user
+            [userId]="spymaster.userId"
+            [color]="spymaster.cssClass"
+            [navToScorecard]="false">
+          </app-user>
+          <div class="spymaster-stat">
+            <span class="value">{{ spymaster.cluesGiven }}</span> clues given
+          </div>
+          <div class="spymaster-stat" *ngIf="spymaster.avgClueSize">
+            <span class="value">{{ spymaster.avgClueSize }}</span> avg words per clue
+          </div>
+          <div class="spymaster-stat" *ngIf="spymaster.accuracyPct !== undefined">
+            <span class="value">{{ spymaster.accuracyPct }}%</span> team guess accuracy
+          </div>
+          <div class="spymaster-stat" *ngIf="spymaster.perfectClues">
+            <span class="value">{{ spymaster.perfectClues }}</span>
+            perfect clue{{ spymaster.perfectClues > 1 ? "s" : "" }} 💯
+          </div>
+          <div class="spymaster-stat" *ngIf="spymaster.bestClue">
+            best clue:
+            <span class="value">{{ spymaster.bestClue.word }}</span>
+            ({{ spymaster.bestClue.correct }} found)
+          </div>
+        </div>
+      </div>
+    </ng-container>
+
+    <!-- round by round -->
+    <ng-container *ngIf="rounds.length">
+      <h2>Round by Round</h2>
+      <div class="round-row" *ngFor="let round of rounds; let i = index">
+        <div class="round-num">{{ i + 1 }}</div>
+        <app-clue
+          class="round-clue"
+          [clue]="round.clue"
+          [assetUrlPattern]="game.assetUrlPattern">
+        </app-clue>
+        <div class="round-duration" *ngIf="round.durationText" tooltip="Round duration">
+          {{ round.durationText }}
+        </div>
+      </div>
+    </ng-container>
+
+  </ng-container>
+</ion-content>
+
+<ng-template #spinner>
+  <div class="spinner-container">
+    <ion-spinner></ion-spinner>
+  </div>
+</ng-template>

--- a/src/app/components/game-stats/game-stats.component.scss
+++ b/src/app/components/game-stats/game-stats.component.scss
@@ -1,0 +1,225 @@
+$blue: var(--ion-color-primary);
+$red: var(--ion-color-danger);
+
+h2 {
+  font-size: 18px;
+  font-weight: bold;
+  margin: 24px 0 12px;
+}
+
+.hero {
+  text-align: center;
+
+  .winner {
+    font-size: 28px;
+    font-weight: bold;
+    margin: 8px 0;
+
+    &.blue {
+      color: $blue;
+    }
+    &.red {
+      color: $red;
+    }
+  }
+
+  .hero-chips {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+
+    ion-chip {
+      pointer-events: none;
+    }
+  }
+}
+
+.awards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 10px;
+
+  .award-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 12px 8px;
+    border: 1px solid rgba(var(--ion-color-medium-rgb), 0.4);
+    border-radius: 8px;
+
+    .award-emoji {
+      font-size: 32px;
+      line-height: 1.2;
+    }
+
+    .award-title {
+      font-weight: bold;
+      margin: 4px 0;
+    }
+
+    .award-detail {
+      font-size: 13px;
+      color: var(--ion-color-medium);
+    }
+  }
+}
+
+.team-section {
+  margin-bottom: 20px;
+
+  .team-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+
+    .team-name {
+      font-size: 16px;
+      font-weight: bold;
+
+      &.blue {
+        color: $blue;
+      }
+      &.red {
+        color: $red;
+      }
+    }
+
+    .team-score {
+      font-size: 13px;
+      color: var(--ion-color-medium);
+    }
+  }
+
+  .accuracy-bar {
+    position: relative;
+    height: 20px;
+    margin: 8px 0;
+    border-radius: 10px;
+    background: rgba(var(--ion-color-medium-rgb), 0.25);
+    overflow: hidden;
+
+    .fill {
+      height: 100%;
+      border-radius: 10px;
+      transition: width 500ms ease;
+
+      &.blue {
+        background: $blue;
+      }
+      &.red {
+        background: $red;
+      }
+    }
+
+    .accuracy-label {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      font-weight: bold;
+      color: #fff;
+      text-shadow: 0 0 3px rgba(0, 0, 0, 0.6);
+    }
+  }
+
+  .stats-table {
+    width: 100%;
+    border-collapse: collapse;
+
+    th,
+    td {
+      text-align: center;
+      padding: 4px 2px;
+      border-bottom: 1px solid rgba(var(--ion-color-medium-rgb), 0.25);
+    }
+
+    th {
+      font-size: 14px;
+      font-weight: normal;
+      cursor: default;
+
+      &.player-col {
+        text-align: left;
+      }
+    }
+
+    td.player-col {
+      text-align: left;
+
+      display: flex;
+      align-items: center;
+
+      .spy {
+        width: 18px;
+      }
+    }
+
+    app-elo-change {
+      display: inline-block;
+    }
+  }
+}
+
+.spymaster-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+
+  .spymaster-card {
+    padding: 12px;
+    border-radius: 8px;
+    border: 1px solid rgba(var(--ion-color-medium-rgb), 0.4);
+    border-top-width: 4px;
+
+    &.blue {
+      border-top-color: $blue;
+    }
+    &.red {
+      border-top-color: $red;
+    }
+
+    .spymaster-stat {
+      font-size: 14px;
+      color: var(--ion-color-medium);
+      margin-top: 6px;
+
+      .value {
+        font-weight: bold;
+        color: var(--ion-text-color);
+        text-transform: uppercase;
+      }
+    }
+  }
+}
+
+.round-row {
+  display: flex;
+  align-items: center;
+
+  .round-num {
+    width: 24px;
+    text-align: center;
+    font-weight: bold;
+    color: var(--ion-color-medium);
+    flex-shrink: 0;
+  }
+
+  .round-clue {
+    flex-grow: 1;
+    min-width: 0;
+  }
+
+  .round-duration {
+    width: 60px;
+    flex-shrink: 0;
+    text-align: right;
+    font-size: 13px;
+    color: var(--ion-color-medium);
+  }
+}

--- a/src/app/components/game-stats/game-stats.component.ts
+++ b/src/app/components/game-stats/game-stats.component.ts
@@ -1,0 +1,422 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {ModalController} from '@ionic/angular';
+import {firstValueFrom} from 'rxjs';
+import {take} from 'rxjs/operators';
+import {ClueService} from 'src/app/services/clue.service';
+import {EloHistoryService} from 'src/app/services/elo-history.service';
+import {Clue, Game, GameStatus, TeamType, TileRole} from 'types';
+
+// mirrors BASE_ELO in functions/src/util/elo.ts
+const BASE_ELO = 1200;
+
+export interface PlayerStats {
+  userId: string;
+  team: TeamType;
+  isSpymaster: boolean;
+  guesses: number;
+  correct: number;
+  civilians: number;
+  enemy: number;
+  assassin: number;
+  darts: number;
+  eloDelta?: number;
+}
+
+export interface TeamSummary {
+  team: TeamType;
+  label: string;
+  cssClass: 'blue'|'red';
+  found: number;
+  total: number;
+  cluesGiven: number;
+  guesses: number;
+  correct: number;
+  accuracyPct: number;
+  players: PlayerStats[];
+}
+
+export interface SpymasterStats {
+  userId: string;
+  team: TeamType;
+  cssClass: 'blue'|'red';
+  cluesGiven: number;
+  avgClueSize?: string;
+  correct: number;
+  guesses: number;
+  accuracyPct?: number;
+  perfectClues: number;
+  bestClue?: {word: string, correct: number};
+}
+
+export interface Round {
+  clue: Clue;
+  durationText?: string;
+}
+
+export interface Award {
+  emoji: string;
+  title: string;
+  userId: string;
+  detail: string;
+}
+
+@Component({
+  standalone: false,
+  selector: 'app-game-stats',
+  templateUrl: './game-stats.component.html',
+  styleUrls: ['./game-stats.component.scss'],
+})
+export class GameStatsComponent implements OnInit {
+  @Input() game: Game;
+
+  loading = true;
+  clues: Clue[] = [];
+  rounds: Round[] = [];
+  teamSummaries: TeamSummary[] = [];
+  spymasters: SpymasterStats[] = [];
+  awards: Award[] = [];
+  totalGuesses = 0;
+
+  constructor(
+      private readonly modalCtrl: ModalController,
+      private readonly clueService: ClueService,
+      private readonly eloHistoryService: EloHistoryService,
+  ) {}
+
+  async ngOnInit() {
+    const clues = await firstValueFrom(
+        this.clueService.getClues(this.game.id).pipe(take(1)));
+
+    // getClues returns newest first; the stats read chronologically
+    this.clues = (clues ?? []).slice().reverse();
+    this.buildStats();
+    this.loading = false;
+
+    // elo deltas trickle in afterwards, the table updates in place
+    this.loadEloChanges();
+  }
+
+  get blueWon(): boolean {
+    return this.game.status === GameStatus.BLUE_WON;
+  }
+
+  get winningTeam(): TeamType {
+    return this.blueWon ? TeamType.BLUE : TeamType.RED;
+  }
+
+  // when both teams still have agents on the board, the assassin ended it
+  get endedByAssassin(): boolean {
+    return this.game.blueAgents > 0 && this.game.redAgents > 0;
+  }
+
+  get gameDurationText(): string {
+    return this.formatDuration(this.game.completedAt - this.game.createdAt);
+  }
+
+  dismiss() {
+    this.modalCtrl.dismiss();
+  }
+
+  private buildStats() {
+    const players = new Map<string, PlayerStats>();
+    const addTeam = (team: TeamType, userIds: string[], spymaster?: string) => {
+      for (const userId of userIds) {
+        players.set(userId, {
+          userId,
+          team,
+          isSpymaster: userId === spymaster,
+          guesses: 0,
+          correct: 0,
+          civilians: 0,
+          enemy: 0,
+          assassin: 0,
+          darts: 0,
+        });
+      }
+    };
+    addTeam(
+        TeamType.BLUE, this.game.blueTeam.userIds,
+        this.game.blueTeam.spymaster);
+    addTeam(
+        TeamType.RED, this.game.redTeam.userIds, this.game.redTeam.spymaster);
+
+    // tally every guess from every clue
+    for (const clue of this.clues) {
+      for (const tile of clue.guessesMade ?? []) {
+        this.totalGuesses++;
+        const player = players.get(tile.selectedBy);
+        if (!player) {
+          continue;
+        }
+        player.guesses++;
+        if (tile.dartedBy) {
+          player.darts++;
+        }
+        if ((tile.role as string) === (clue.team as string)) {
+          player.correct++;
+        } else if (tile.role === TileRole.CIVILIAN) {
+          player.civilians++;
+        } else if (tile.role === TileRole.ASSASSIN) {
+          player.assassin++;
+        } else {
+          player.enemy++;
+        }
+      }
+    }
+
+    this.buildRounds();
+    this.buildTeamSummaries(players);
+    this.buildSpymasterStats();
+    this.buildAwards(players);
+  }
+
+  private buildRounds() {
+    this.rounds = this.clues.map((clue, i) => {
+      const end = i + 1 < this.clues.length ? this.clues[i + 1].createdAt :
+                                              this.game.completedAt;
+      return {clue, durationText: this.formatDuration(end - clue.createdAt)};
+    });
+  }
+
+  private buildTeamSummaries(players: Map<string, PlayerStats>) {
+    const tiles = this.game.tiles ?? [];
+    this.teamSummaries = [TeamType.BLUE, TeamType.RED].map(team => {
+      const blue = team === TeamType.BLUE;
+      const teamPlayers =
+          [...players.values()]
+              .filter(p => p.team === team)
+              .sort(
+                  (a, b) => Number(b.isSpymaster) - Number(a.isSpymaster) ||
+                      b.guesses - a.guesses);
+      const teamClues = this.clues.filter(c => (c.team as string) === team);
+      const guesses = teamClues.reduce(
+          (sum, c) => sum + (c.guessesMade?.length ?? 0), 0);
+      const correct = teamClues.reduce(
+          (sum, c) => sum + this.correctGuesses(c), 0);
+      const total =
+          tiles.filter(t => (t.role as string) === (team as string)).length;
+      return {
+        team,
+        label: blue ? 'Blue Team' : 'Red Team',
+        cssClass: blue ? 'blue' as const : 'red' as const,
+        found: total -
+            (blue ? this.game.blueAgents : this.game.redAgents),
+        total,
+        cluesGiven: teamClues.length,
+        guesses,
+        correct,
+        accuracyPct: guesses ? Math.round(correct / guesses * 100) : 0,
+        players: teamPlayers,
+      };
+    });
+  }
+
+  private buildSpymasterStats() {
+    this.spymasters = [];
+    for (const team of [TeamType.BLUE, TeamType.RED]) {
+      const blue = team === TeamType.BLUE;
+      const userId = blue ? this.game.blueTeam.spymaster :
+                            this.game.redTeam.spymaster;
+      if (!userId) {
+        continue;
+      }
+      const teamClues = this.clues.filter(c => (c.team as string) === team);
+      const guesses = teamClues.reduce(
+          (sum, c) => sum + (c.guessesMade?.length ?? 0), 0);
+      const correct = teamClues.reduce(
+          (sum, c) => sum + this.correctGuesses(c), 0);
+
+      // average intended clue size, skipping non-numeric counts like ∞
+      const numericCounts = teamClues.map(c => parseInt(c.guessCount, 10))
+                                .filter(n => !isNaN(n) && n > 0);
+      const avg = numericCounts.length ?
+          numericCounts.reduce((a, b) => a + b, 0) / numericCounts.length :
+          undefined;
+
+      let bestClue: {word: string, correct: number};
+      for (const clue of teamClues) {
+        const clueCorrect = this.correctGuesses(clue);
+        if (clueCorrect > 0 && clueCorrect > (bestClue?.correct ?? 0)) {
+          bestClue = {word: clue.word, correct: clueCorrect};
+        }
+      }
+
+      this.spymasters.push({
+        userId,
+        team,
+        cssClass: blue ? 'blue' : 'red',
+        cluesGiven: teamClues.length,
+        avgClueSize: avg !== undefined ? avg.toFixed(1) : undefined,
+        correct,
+        guesses,
+        accuracyPct: guesses ? Math.round(correct / guesses * 100) : undefined,
+        perfectClues: teamClues.filter(c => this.isPerfect(c)).length,
+        bestClue,
+      });
+    }
+  }
+
+  private buildAwards(players: Map<string, PlayerStats>) {
+    this.awards = [];
+    const all = [...players.values()];
+    const maxBy = (candidates: PlayerStats[], value: (p: PlayerStats) => number,
+                   min: number) => {
+      let best: PlayerStats;
+      for (const candidate of candidates) {
+        if (!best || value(candidate) > value(best)) {
+          best = candidate;
+        }
+      }
+      return best && value(best) >= min ? best : undefined;
+    };
+
+    // winning guess, unless the other team handed it over via the assassin
+    const lastClue = this.clues[this.clues.length - 1];
+    const lastGuess =
+        lastClue?.guessesMade?.[lastClue.guessesMade.length - 1];
+    if (!this.endedByAssassin && lastGuess &&
+        (lastClue.team as string) === (this.winningTeam as string) &&
+        (lastGuess.role as string) === (this.winningTeam as string) &&
+        players.has(lastGuess.selectedBy)) {
+      this.awards.push({
+        emoji: '🏆',
+        title: 'Clutch',
+        userId: lastGuess.selectedBy,
+        detail: `won the game on ${this.tileName(lastGuess.word)}`,
+      });
+    }
+
+    const sharpshooter = maxBy(
+        all.filter(p => p.guesses >= 2),
+        p => p.correct / p.guesses * 1000 + p.correct, 0);
+    if (sharpshooter && sharpshooter.correct > 0) {
+      this.awards.push({
+        emoji: '🎯',
+        title: 'Sharpshooter',
+        userId: sharpshooter.userId,
+        detail: `${sharpshooter.correct}/${
+            sharpshooter.guesses} guesses correct`,
+      });
+    }
+
+    const busiest = maxBy(all, p => p.guesses, 3);
+    if (busiest) {
+      this.awards.push({
+        emoji: '🖱️',
+        title: 'Trigger Happy',
+        userId: busiest.userId,
+        detail: `made ${busiest.guesses} guesses`,
+      });
+    }
+
+    const bestSpymasterClue = this.spymasters.filter(s => s.bestClue)
+                                  .sort(
+                                      (a, b) => b.bestClue.correct -
+                                          a.bestClue.correct)[0];
+    if (bestSpymasterClue?.bestClue.correct >= 3) {
+      this.awards.push({
+        emoji: '🧠',
+        title: 'Galaxy Brain',
+        userId: bestSpymasterClue.userId,
+        detail: `"${bestSpymasterClue.bestClue.word}" found ${
+            bestSpymasterClue.bestClue.correct} agents`,
+      });
+    }
+
+    const civilianMagnet = maxBy(all, p => p.civilians, 2);
+    if (civilianMagnet) {
+      this.awards.push({
+        emoji: '🙈',
+        title: 'Civilian Magnet',
+        userId: civilianMagnet.userId,
+        detail: `bumped into ${civilianMagnet.civilians} civilians`,
+      });
+    }
+
+    const doubleAgent = maxBy(all, p => p.enemy, 1);
+    if (doubleAgent) {
+      this.awards.push({
+        emoji: '🎁',
+        title: 'Double Agent',
+        userId: doubleAgent.userId,
+        detail: `revealed ${doubleAgent.enemy} enemy agent${
+            doubleAgent.enemy > 1 ? 's' : ''}`,
+      });
+    }
+
+    const assassinVictim = all.find(p => p.assassin > 0);
+    if (assassinVictim) {
+      this.awards.push({
+        emoji: '💀',
+        title: 'Fatal Touch',
+        userId: assassinVictim.userId,
+        detail: 'found the assassin the hard way',
+      });
+    }
+
+    const dartChampion = maxBy(all, p => p.darts, 1);
+    if (dartChampion) {
+      this.awards.push({
+        emoji: '🎪',
+        title: 'Dart Devil',
+        userId: dartChampion.userId,
+        detail: `threw ${dartChampion.darts} dart${
+            dartChampion.darts > 1 ? 's' : ''}`,
+      });
+    }
+  }
+
+  private async loadEloChanges() {
+    try {
+      const stats = await this.eloHistoryService.getStatsForGame(this.game.id);
+      await Promise.all(stats.map(async stat => {
+        const before =
+            await this.eloHistoryService.getEloAt(stat.timestamp - 1,
+                                                  stat.userId);
+        const player = this.teamSummaries.flatMap(t => t.players)
+                           .find(p => p.userId === stat.userId);
+        if (player) {
+          player.eloDelta = Math.round(stat.elo - (before?.elo ?? BASE_ELO));
+        }
+      }));
+    } catch (_e) {
+      // elo deltas are a nice-to-have; leave the column blank on failure
+    }
+  }
+
+  private correctGuesses(clue: Clue): number {
+    return (clue.guessesMade ?? [])
+        .filter(tile => (tile.role as string) === (clue.team as string))
+        .length;
+  }
+
+  // a perfect clue: every intended guess was made and every one was correct
+  private isPerfect(clue: Clue): boolean {
+    const intended = parseInt(clue.guessCount, 10);
+    const guesses = clue.guessesMade ?? [];
+    return !isNaN(intended) && intended > 0 && guesses.length === intended &&
+        this.correctGuesses(clue) === intended;
+  }
+
+  // picture-based games have no tile word to name the winning tile
+  private tileName(word?: string): string {
+    return word ? `"${word.toUpperCase()}"` : 'the last tile';
+  }
+
+  formatDuration(ms: number): string {
+    if (!ms || ms < 0 || isNaN(ms)) {
+      return '';
+    }
+    const totalSeconds = Math.round(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    if (hours) {
+      return `${hours}h ${minutes}m`;
+    }
+    if (minutes) {
+      return `${minutes}m ${seconds}s`;
+    }
+    return `${seconds}s`;
+  }
+}

--- a/src/app/components/game/game.component.html
+++ b/src/app/components/game/game.component.html
@@ -4,10 +4,19 @@
   <div>
     <ion-button
       fill="outline"
+      color="primary"
+      (click)="openStats()"
+      *ngIf="game.completedAt"
+    >
+      <ion-icon slot="start" name="podium-outline"></ion-icon>
+      Stats
+    </ion-button>
+    <ion-button
+      fill="outline"
       [color]="throwingDart ? 'danger' : 'medium'"
       (click)="toggleThrowingDart()"
       [disabled]="disableEndTurn"
-      *ngIf="!spymaster"
+      *ngIf="!spymaster && !game.completedAt"
     >
       {{ throwingDart ? "Cancel" : "Dart 🎯" }}
     </ion-button>

--- a/src/app/components/game/game.component.ts
+++ b/src/app/components/game/game.component.ts
@@ -1,8 +1,11 @@
 import {Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {ModalController} from '@ionic/angular';
 import {AuthService} from 'src/app/services/auth.service';
 import {GameService} from 'src/app/services/game.service';
 import {UtilService} from 'src/app/services/util.service';
 import {Clue, Game, GameStatus, Room, TeamType} from 'types';
+
+import {GameStatsComponent} from '../game-stats/game-stats.component';
 
 @Component({
   standalone: false,
@@ -22,7 +25,17 @@ export class GameComponent implements OnInit, OnDestroy {
       private readonly authService: AuthService,
       private readonly gameService: GameService,
       private readonly utilService: UtilService,
+      private readonly modalCtrl: ModalController,
   ) {}
+
+  async openStats() {
+    const modal = await this.modalCtrl.create({
+      component: GameStatsComponent,
+      componentProps: {game: this.game},
+      cssClass: 'game-stats-modal',
+    });
+    await modal.present();
+  }
 
   ngOnInit() {
     document.addEventListener('mousemove', this.handleMouseMove.bind(this));

--- a/src/app/services/elo-history.service.ts
+++ b/src/app/services/elo-history.service.ts
@@ -52,6 +52,19 @@ export class EloHistoryService {
   }
 
   /**
+   * Returns the stats snapshots written for every player in a given game
+   */
+  async getStatsForGame(gameId: string): Promise<Stats[]> {
+    const q = query(
+        collection(this.firestore, 'eloHistory'),
+        where('gameId', '==', gameId),
+    );
+    return await firstValueFrom(
+               collectionData(q).pipe(take(1)) as any,
+               ) as Stats[];
+  }
+
+  /**
    * Returns either the first record for a player before a given
    * timestamp, or undefined if none are found before the timestamp
    */

--- a/src/global.scss
+++ b/src/global.scss
@@ -37,6 +37,13 @@
   font-size: 20px;
 }
 
+// post-game stats dialog opened from the game component
+ion-modal.game-stats-modal {
+  --width: min(720px, 95vw);
+  --height: min(92vh, 860px);
+  --border-radius: 12px;
+}
+
 .space-between {
   display: flex;
   // ion-card-header's shadow :host styles set flex-direction: column


### PR DESCRIPTION
Completed games now show a **Stats** button in the score bar — both right when a game ends and when revisiting a historical game — that opens a colonist.io-style summary dialog.

## What's in the dialog

- **Winner hero** — team, game duration, clue count, total guesses, and an "Ended by assassin" badge when applicable
- **Awards** — fun highlight cards computed from the guess history: 🏆 Clutch (winning guess), 🎯 Sharpshooter (best accuracy), 🖱️ Trigger Happy (most guesses), 🧠 Galaxy Brain (spymaster clue that found 3+ agents), 🙈 Civilian Magnet, 🎁 Double Agent, 💀 Fatal Touch (hit the assassin), 🎪 Dart Devil. Each award only appears when someone earned it
- **Team sections** — agents found, guess-accuracy bar, and a per-player table: guesses, correct, civilians, enemy agents revealed, assassin, darts, and Elo change (reuses `app-elo-change`)
- **Spymaster Duel** — clues given, avg words per clue, team accuracy, perfect clues 💯, best clue
- **Round by Round** — clue timeline (reuses `app-clue`) with per-round durations

## Implementation notes

- Stats are derived client-side from the game document plus its `clues` subcollection (each guess records `selectedBy`, role, darts)
- Elo deltas come from a new `EloHistoryService.getStatsForGame` (single-field `gameId` equality query — no new Firestore index needed), with pre-game rating via the existing `getEloAt`
- Games predating clue history show the hero plus a "no detailed stats" note instead of empty tables
- User chips inside the dialog don't navigate to scorecards (navigating beneath an open modal would be confusing)
- The dart button is hidden once a game completes (it was already disabled then) to make room for the Stats button

## Testing

- `npm run build`, `npm run build:prod`, and `npm run lint` all pass
- Verified visually against the local emulators with a seeded 7-round completed game (desktop + mobile viewports): awards, tables, elo deltas, spymaster duel, and round timeline all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNK1EqKtoYrH8LJ3n3XNxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNK1EqKtoYrH8LJ3n3XNxW)_